### PR TITLE
Support for x-id Query Parameter Added by aws-sdk-go-v2 and Other AWS SDKs

### DIFF
--- a/src/handlers/deleteObject.ts
+++ b/src/handlers/deleteObject.ts
@@ -2,6 +2,7 @@ import { type Request, type Response, type NextFunction } from "express"
 import Responses from "../responses"
 import type Server from "../"
 import { extractKeyAndBucketFromRequestParams } from "../utils"
+import { validateQuery } from "../validate-query"
 
 export class DeleteObject {
 	public constructor(private readonly server: Server) {
@@ -10,7 +11,8 @@ export class DeleteObject {
 
 	public async handle(req: Request, res: Response, next: NextFunction): Promise<void> {
 		try {
-			if (req.url.includes("?")) {
+			const isQueryAllowed = validateQuery(req.query, { "x-id": "DeleteObject" })
+			if (!isQueryAllowed) {
 				next()
 
 				return

--- a/src/handlers/deleteObjects.ts
+++ b/src/handlers/deleteObjects.ts
@@ -4,6 +4,7 @@ import type Server from "../"
 import { streamToXML, promiseAllSettledChunked, extractKeyAndBucketFromRequestParams } from "../utils"
 import pathModule from "path"
 import { Readable } from "stream"
+import { validateQuery } from "../validate-query"
 
 export type DeleteObjectsXML = {
 	Delete?: {
@@ -18,7 +19,8 @@ export class DeleteObjects {
 
 	public async handle(req: Request, res: Response, next: NextFunction): Promise<void> {
 		try {
-			if (!req.url.includes("?delete") || typeof req.decodedBody === "undefined") {
+			const isQueryAllowed = validateQuery(req.query, { delete: { required: true, anyValue: true }, "x-id": "DeleteObjects" })
+			if (!isQueryAllowed || typeof req.decodedBody === "undefined") {
 				next()
 
 				return

--- a/src/handlers/getObject.ts
+++ b/src/handlers/getObject.ts
@@ -5,6 +5,7 @@ import { Readable } from "stream"
 import { type ReadableStream as ReadableStreamWebType } from "stream/web"
 import mimeTypes from "mime-types"
 import { parseByteRange, extractKeyAndBucketFromRequestParams } from "../utils"
+import { validateQuery } from "../validate-query"
 
 export class GetObject {
 	public constructor(private readonly server: Server) {
@@ -13,7 +14,8 @@ export class GetObject {
 
 	public async handle(req: Request, res: Response, next: NextFunction): Promise<void> {
 		try {
-			if (req.url.includes("?")) {
+			const isQueryAllowed = validateQuery(req.query, { "x-id": "GetObject" })
+			if (!isQueryAllowed) {
 				next()
 
 				return

--- a/src/handlers/headObject.ts
+++ b/src/handlers/headObject.ts
@@ -3,6 +3,7 @@ import Responses from "../responses"
 import type Server from "../"
 import { extractKeyAndBucketFromRequestParams } from "../utils"
 import mimeTypes from "mime-types"
+import { validateQuery } from "../validate-query"
 
 export class HeadObject {
 	public constructor(private readonly server: Server) {
@@ -11,7 +12,8 @@ export class HeadObject {
 
 	public async handle(req: Request, res: Response, next: NextFunction): Promise<void> {
 		try {
-			if (req.url.includes("?")) {
+			const isQueryAllowed = validateQuery(req.query, { "x-id": "HeadObject" })
+			if (!isQueryAllowed) {
 				next()
 
 				return

--- a/src/handlers/putObject.ts
+++ b/src/handlers/putObject.ts
@@ -4,6 +4,7 @@ import type Server from "../"
 import pathModule from "path"
 import { normalizeKey, extractKeyAndBucketFromRequestParams, convertTimestampToMs, isValidObjectKey } from "../utils"
 import { Readable } from "stream"
+import { validateQuery } from "../validate-query"
 
 export class PutObject {
 	public constructor(private readonly server: Server) {
@@ -95,7 +96,8 @@ export class PutObject {
 
 	public async handle(req: Request, res: Response, next: NextFunction): Promise<void> {
 		try {
-			if (req.url.includes("?")) {
+			const isQueryAllowed = validateQuery(req.query, { "x-id": "PutObject" })
+			if (!isQueryAllowed) {
 				next()
 
 				return

--- a/src/validate-query.ts
+++ b/src/validate-query.ts
@@ -1,0 +1,47 @@
+import { type Request } from "express"
+
+/**
+ * Validate query parameters against allowed values.
+ * @date 4/16/2024 - 11:10:34 AM
+ * @export
+ * @param {Request["query"]} query - The Express request query object.
+ * @param {Record<string, string | AllowedValue | AllowedValueAny>} [allowedValues={}] - Allowed values for each query key.
+ * @param {boolean isMissingRuleValid} [isMissingRuleValid=false] - If true, allows query keys not present in allowedValues.
+ * @returns {boolean} - True if all query parameters are valid, false otherwise.
+ */
+
+type AllowedValue = {
+	value: unknown
+	required?: boolean
+	// minLength?: number
+	exact?: boolean
+}
+
+type AllowedValueAny = {
+	anyValue: true
+	required?: boolean
+}
+export function validateQuery(
+	query: Request["query"],
+	allowedValues: Record<string, string | AllowedValue | AllowedValueAny> = {},
+	isMissingRuleValid: boolean = false
+): boolean {
+	const isObject = (v: unknown): v is AllowedValue & AllowedValueAny => typeof v === "object" && v !== null && !Array.isArray(v)
+	const allowedEntries = Object.entries(allowedValues)
+	for (const [key, rule] of allowedEntries) {
+		if (isObject(rule)) {
+			if (rule.required && !(key in query)) return false
+			// if (typeof rule.minLength === "number" && typeof query[key] === "string" && (query[key] as string).length < rule.minLength) return false
+		}
+	}
+	const queryEntries = Object.entries(query)
+	const toLowerCase = (v: unknown, exact?: boolean) => (typeof v === "string" && !exact ? v.toLowerCase() : v)
+	for (const [key, value] of queryEntries) {
+		const found = allowedValues[key]
+		if (!found && isMissingRuleValid === true) continue // no rule found & valid to have unaccounted for params
+		const rule = isObject(found) ? found : ({ value: found } as AllowedValue & AllowedValueAny)
+		if (rule.anyValue) continue
+		if (toLowerCase(rule.value, rule.exact) !== toLowerCase(value, rule.exact)) return false
+	}
+	return true
+}


### PR DESCRIPTION
### Problem
When using the aws-sdk-go-v2 library (and other AWS SDKs), requests to S3 APIs often include an `x-id` query parameter (e.g., x-id=DeleteObjects, x-id=PutObject, x-id=GetObject, etc.).

### Issue
Current implementation in some handlers (`GetObject`, `HeadObject`, `PutObject`, `DeleteObject`, `DeleteObjects`*) does not account for this parameter and automatically rejects any query parameters present in the URL.

### Solution
Update the handlers to allow an optional `x-id` query parameter, ensuring compatibility with requests generated by AWS SDKs.

### Notes
- *Additional implementation ensures that the `delete` query parameter is still required in the `DeleteObjects` handler
- [related discussion](https://github.com/aws/aws-sdk-go-v2/discussions/2847)