### PR TITLE
Minify XML responses to improve compatibility

### DIFF
--- a/src/responses.ts
+++ b/src/responses.ts
@@ -8,6 +8,9 @@ export class Responses {
 		xmldec: {
 			version: "1.0",
 			encoding: "utf-8"
+		},
+		renderOpts: {
+			pretty: false
 		}
 	})
 


### PR DESCRIPTION
## Description
When using the MinIO CLI with `filen-s3`, `putObject` requests fail. After debugging, I discovered the issue is related to how the MinIO XML parser handles the bucket location returned by `getBucketLocation`.

## Details
- The `filen-s3` XML response from `getBucketLocation` contains newlines.
- `MinIO CLI`  does not trim these newlines when parsing the bucket location.
- As a result, MinIO interprets the location as `"\n \n"`.
- This invalid location propagates into the `Authorization` header as `"\n \n"`.
- Any subsequent `putObject` requests fail due to the malformed header.
- From my limited testing, AWS XML responses do not contain new lines.
- Due to AWS not having newlines, I suggest a small fix is implemented in this repository, even though technically one could also argue that the MinIO XML Parser should be fixed instead

## Steps to Reproduce
1. Configure `MinIO CLI` to use a filen-s3 instance. `mc alias set temporary http://$FILEN_S3_LOCATION $SECRET_ID $SECRET_KEY" --path on --api S3v4`
3. Attempt to upload an object using `putObject`. `mc cp test temporary/coolify --debug --insecure`
4. Observe that the request fails due to an invalid Authorization header.

> <ERROR> Failed to copy `test`. Put "http://localhost/test/test": net/http: invalid header field value for "Authorization"
 (3) /dev/mc/cmd/cp-main.go:491 cmd.doCopySession(..) Tags: [\dev\mc\Dockerfile]
 (2) /dev/mc/cmd/common-methods.go:520 cmd.uploadSourceToTargetURL(..) Tags: [\dev\mc\Dockerfile]
 (1) /dev/mc/cmd/common-methods.go:213 cmd.putTargetStream(..) Tags: [temporary, http://localhost/test/test]
 (0) /dev/mc/cmd/client-s3.go:1168 cmd.(*S3Client).Put(..)
 Release-Tag:DEVELOPMENT.GOGET | Commit:DEVELOPMENT. | Host:DESKTOP| OS:windows | Arch:amd64 | Lang:go1.25.5 | Mem:7.3 MiB/18 MiB | Heap:7.3 MiB/11 MiB

## Expected Behavior
`getBucketLocation` repsonse should not contain new lines.

## Proposed Solution
Turn of pretty printing of XML responses, by setting `pretty` to `false`. This eliminates newlines.

## Environment
- `filen-s3` version: `0.3.1`
- MinIO version: `RELEASE.2025-08-13T08-35-41`
- Tested on Linux and Windows
